### PR TITLE
Move modules to Router

### DIFF
--- a/contracts/router/Module.sol
+++ b/contracts/router/Module.sol
@@ -25,8 +25,6 @@ abstract contract Module {
     address internal immutable __self = address(this);
 
     // Errors
-    error IsDelegated();
-    error NotDelegated();
     error OwnableUnauthorizedAccount(address account);
 
     // Commands
@@ -37,13 +35,5 @@ abstract contract Module {
         if (s.owners[__self] != msg.sender) {
             revert OwnableUnauthorizedAccount(msg.sender);
         }
-    }
-
-    function enforceIsDelegated() internal view {
-        if (address(this) == __self) revert NotDelegated();
-    }
-
-    function enforceNotDelegated() internal view {
-        if (address(this) != __self) revert IsDelegated();
     }
 }

--- a/contracts/router/Module.sol
+++ b/contracts/router/Module.sol
@@ -3,11 +3,9 @@ pragma solidity ^0.8.20;
 
 struct Store {
     mapping(address => address) owners;
-    mapping(bytes4 => address) modules;
 }
 
 library ModuleLib {
-    // Stores
     bytes32 private constant STORE_POSITION =
         keccak256(
             abi.encode(uint256(keccak256("cavalre.storage.Module")) - 1)

--- a/contracts/router/Router.sol
+++ b/contracts/router/Router.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {Module, ModuleLib as ML, Store} from "./Module.sol";
+import {Module, ModuleLib as ML, Store as MS} from "./Module.sol";
 
 contract Router is Module {
     // Events
@@ -16,7 +16,7 @@ contract Router is Module {
     error ModuleNotFound(address _module);
 
     constructor(address owner_) {
-        Store storage s = ML.store();
+        MS storage s = ML.store();
         s.owners[__self] = owner_;
         emit RouterCreated(__self);
     }
@@ -54,7 +54,7 @@ contract Router is Module {
     }
 
     function setCommand(bytes4 _command, address _module) public {
-        Store storage s = enforceIsOwner();
+        MS storage s = enforceIsOwner();
         if (s.modules[_command] == _module)
             revert CommandAlreadySet(_command, _module);
         s.modules[_command] = _module;


### PR DESCRIPTION
`store().modules` is only used in Router and this change makes modules independent of the Router. With this change, we could support the diamond standard.