### PR TITLE
refactor: replace string requires with custom errors

### DIFF
--- a/examples/Token.sol
+++ b/examples/Token.sol
@@ -15,6 +15,8 @@ library TokenLib {
 }
 
 contract TestToken is ERC20 {
+    error WithdrawTransferFailed();
+
     event Deposit(address indexed dst, uint256 wad);
     event Withdrawal(address indexed src, uint256 wad);
 
@@ -62,7 +64,7 @@ contract TestToken is ERC20 {
         require(balanceOf(_msgSender()) >= wad);
         burn(wad);
         (bool success,) = payable(_msgSender()).call{value: wad}("");
-        require(success, "Transfer failed");
+        if (!success) revert WithdrawTransferFailed();
         emit Withdrawal(_msgSender(), wad);
     }
 }

--- a/interfaces/ILedger.sol
+++ b/interfaces/ILedger.sol
@@ -117,6 +117,7 @@ interface ILedger {
     error InvalidSubAccountIndex(uint256 index);
     error InvalidToken(address token, string name, string symbol, uint8 decimals);
     error MaxDepthExceeded();
+    error NativeTransferFailed();
     error SubAccountNotFound(address addr);
     error SubAccountGroupNotFound(string subName);
     error Unauthorized(address user);

--- a/libraries/FloatLib.sol
+++ b/libraries/FloatLib.sol
@@ -40,6 +40,13 @@ library FloatLib {
     Float constant TEN = Float.wrap(((ONE_EXPONENT + 1) << MANTISSA_BITS) | ONE_MANTISSA);
     Float constant HALF = Float.wrap(((ONE_EXPONENT - 1) << MANTISSA_BITS) | (5 * ONE_MANTISSA));
 
+    error FloatNegativeValue();
+    error LogNonPositive();
+    error PowBaseNotPositive();
+    error PowExponentTooSmall();
+    error PowZeroBase();
+    error ShiftMagnitudeTooLarge();
+
     //=================
     //   Conversions
     //=================
@@ -67,7 +74,7 @@ library FloatLib {
     //------------
     function toUInt(Float a_, uint8 decimals_) internal pure returns (uint256) {
         (int256 _m, int256 _e) = components(a_);
-        require(_m >= 0, "Value must be non-negative");
+        if (_m < 0) revert FloatNegativeValue();
         _e += int256(uint256(decimals_));
         if (_e >= 0) {
             return uint256(_m) * 10 ** uint256(_e);
@@ -189,7 +196,7 @@ library FloatLib {
             }
         } else {
             _shift = -_shift;
-            require(_shift <= int256(SIGNIFICANT_DIGITS), "shift: |i| too large");
+            if (_shift > int256(SIGNIFICANT_DIGITS)) revert ShiftMagnitudeTooLarge();
             while (_shift >= 16) {
                 _m *= 1e16;
                 _shift -= 16;
@@ -390,7 +397,7 @@ library FloatLib {
     function log(Float x_) internal pure returns (Float) {
         Float _x = normalize(x_);
         (int256 _m, int256 _e) = components(_x);
-        require(_m > 0, "log non-positive");
+        if (_m <= 0) revert LogNonPositive();
 
         int256 _lnWad = (_m * 1e18).lnWad() + _e * LOG10_WAD;
 
@@ -424,8 +431,8 @@ library FloatLib {
     function powInt(Float base_, int256 e_) internal pure returns (Float) {
         Float _base = normalize(base_);
         if (e_ >= 0) return powUint(_base, uint256(e_));
-        require(mantissa(_base) != 0, "pow: zero base");
-        require(e_ != type(int256).min, "pow: exponent too small");
+        if (mantissa(_base) == 0) revert PowZeroBase();
+        if (e_ == type(int256).min) revert PowExponentTooSmall();
         Float _pos = powUint(_base, uint256(-e_));
         return ONE.divide(_pos);
     }
@@ -435,7 +442,7 @@ library FloatLib {
         Float _base = normalize(base_);
         if (mantissa(e_) == 0) return ONE;
         if (_base.isEQ(ONE)) return ONE;
-        require(mantissa(_base) > 0, "pow: base must be positive");
+        if (mantissa(_base) <= 0) revert PowBaseNotPositive();
         return exp(log(_base).times(e_));
     }
 

--- a/libraries/LedgerLib.sol
+++ b/libraries/LedgerLib.sol
@@ -609,7 +609,7 @@ library LedgerLib {
         if (token_ == NATIVE_ADDRESS) {
             transfer(token_, msg.sender, sourceParent_, source_, amount_);
             (bool _success,) = payable(msg.sender).call{value: amount_}("");
-            require(_success);
+            if (!_success) revert ILedger.NativeTransferFailed();
         } else {
             transfer(token_, msg.sender, sourceParent_, source_, amount_);
             SafeERC20.safeTransfer(IERC20(token_), msg.sender, amount_);

--- a/modules/Router.sol
+++ b/modules/Router.sol
@@ -18,6 +18,7 @@ contract Router is Module {
     // Errors
     error CommandAlreadySet(bytes4 _command, address _module);
     error CommandNotFound(bytes4 _command);
+    error GetCommandsFailed(address module);
     error ModuleNotFound(address _module);
 
     constructor(address owner_) {
@@ -50,7 +51,7 @@ contract Router is Module {
 
     function getCommands(address module_) public returns (bytes4[] memory) {
         (bool _success, bytes memory _data) = module_.call(abi.encodeWithSignature("selectors()"));
-        require(_success, "Command: getCommands failed");
+        if (!_success) revert GetCommandsFailed(module_);
         return abi.decode(_data, (bytes4[]));
     }
 


### PR DESCRIPTION
- Router: GetCommandsFailed(address module) when getCommands(module) fails
- ILedger + LedgerLib: NativeTransferFailed() on native unwrap send failure
- FloatLib: FloatNegativeValue, ShiftMagnitudeTooLarge, LogNonPositive, PowZeroBase, PowExponentTooSmall, PowBaseNotPositive for conversion/pow
- examples/Token: WithdrawTransferFailed() on withdraw ETH send failure

Benefits: lower revert gas, stable ABI selectors, typed revert data.