### PR TITLE
chore: unify pragma to ^0.8.26 in test and example files

### DIFF
--- a/tests/examples/ERC20.t.sol
+++ b/tests/examples/ERC20.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.26;
 
 import {Router} from "../../modules/Router.sol";
 import {ERC20, ERC20Lib} from "../../examples/ERC20.sol";

--- a/tests/examples/Sentry.t.sol
+++ b/tests/examples/Sentry.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.26;
 
 import {Router} from "../../modules/Router.sol";
 import {Module, ModuleLib} from "../../modules/Module.sol";

--- a/tests/examples/Token.t.sol
+++ b/tests/examples/Token.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.26;
 
 import {Router} from "../../modules/Router.sol";
 import {ERC20, ERC20Lib} from "../../examples/ERC20.sol";

--- a/tests/libraries/FloatLib.t.sol
+++ b/tests/libraries/FloatLib.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Unlicense
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import {FloatLib, Float} from "../../libraries/FloatLib.sol";
 import {FloatStrings} from "../../libraries/FloatStrings.sol";

--- a/tests/libraries/RandomLib.t.sol
+++ b/tests/libraries/RandomLib.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.26;
+pragma solidity ^0.8.26;
 
 import {Test} from "forge-std/src/Test.sol";
 import {console} from "forge-std/src/console.sol";

--- a/tests/modules/Module.t.sol
+++ b/tests/modules/Module.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.26;
 
 import {Router} from "../../modules/Router.sol";
 import {Test} from "forge-std/src/Test.sol";

--- a/tests/modules/Router.t.sol
+++ b/tests/modules/Router.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.26;
 
 import {Module} from "../../modules/Module.sol";
 import {Router} from "../../modules/Router.sol";


### PR DESCRIPTION
- tests/modules: Router.t.sol, Module.t.sol ^0.8.0 -> ^0.8.26
- tests/examples: Token.t.sol, Sentry.t.sol, ERC20.t.sol ^0.8.0 -> ^0.8.26
- tests/libraries: FloatLib.t.sol, RandomLib.t.sol 0.8.26 -> ^0.8.26

Matches main contracts and foundry.toml solc_version.